### PR TITLE
Update Request.php

### DIFF
--- a/src/Common/Request.php
+++ b/src/Common/Request.php
@@ -154,7 +154,8 @@ abstract class Request implements \JsonSerializable
         $options = [
             "timeout" => 60,
             "connect_timeout" => 60,
-            "exceptions" => false
+            "exceptions" => false,
+            "http_errors" => false,
         ];
 
         // Set data


### PR DESCRIPTION
Add `"http_errors" => false` in the Guzzle sending request options (see https://docs.guzzlephp.org/en/stable/request-options.html#http-errors)
Without it, if Rocket.chat API returns an error (e.g. "User already in role [error-user-already-in-role]"), Guzzle throw a RequestException instead of returning the error. So the `$role->getError();` is not triggered and the script stops.