### PR TITLE
Fix trying to get property of non-object login error

### DIFF
--- a/src/Chat.php
+++ b/src/Chat.php
@@ -24,7 +24,7 @@ class Chat extends Request
     {
         static::send("login", "POST", ["user" => $userName, "password" => $password]);
 
-        if (isset(static::getResponse()->status) && (static::getResponse()->status != "success")) { // Own error structure
+        if (!isset(static::getResponse()->status) || (static::getResponse()->status != "success")) { // Own error structure
 
             if (isset(static::getResponse()->error)) {
                 static::setError(static::getResponse()->error);


### PR DESCRIPTION
If the server is not available `static::getResponse()` remains empty
`src/Chat.php:27 if (isset(static::getResponse()->status) && (static::getResponse()->status != "success")) {`
doesn't handle this case because status is not isset
As a result, we get the error "Trying to get property of non-object" in the lines
`src/Chat.php:39 static::setAuthUserId(static::getResponse()->data->userId);`
and
`src/Chat.php:44 return User::createOutOfResponse(static::getResponse()->data->me);`
because data does not exist
This PR fixes this behavior